### PR TITLE
헤로쿠에 배포하기 - DB 변경 (ClearDB -> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,6 +42,7 @@ spring:
 spring:
   config.activate.on-profile: heroku # profiles.active 에서 바뀌었다고함.. 프로파일명 세팅
   datasource:
-    url: ${CLEARDB_DATABASE_URL} # 환경변수 넣기
+    url: ${JAWSDB_URL} # 환경변수 넣기
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
ClearDB의 MySQL의 버전이 낮아서 문제가 발생
`article_comment.content` 인덱스 사이즈가 너무 큼
ClearDB 의 기본 MySQL 버전이 `5.6`
JawsDB 의 기본 MySQL 버전은 `8.0`

This fixes #44 